### PR TITLE
Change travis badge to correct link after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OrbitDB Time Machine
 
-[![Build Status](https://travis-ci.com/justincqz/orbitdb-time-machine.svg?branch=master)](https://travis-ci.com/justincqz/orbitdb-time-machine)
+[![Build Status](https://travis-ci.com/justincqz/orbit-db-time-machine.svg?branch=master)](https://travis-ci.com/justincqz/orbit-db-time-machine)
 
 A logical time machine for OrbitDB


### PR DESCRIPTION
Due to the name change, the travis icon has to be updated