### PR TITLE
Add empty log rendering in timeline view

### DIFF
--- a/src/components/GraphDisplay.module.css
+++ b/src/components/GraphDisplay.module.css
@@ -1,3 +1,13 @@
-.graph {
-  flex-basis: 1;
+.graphContainer {
+  width: 100%; 
+  height: 20%; 
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.emptyGraph {
+  font-size: 3vh;
+  font-family: monospace;
+  color: #b8d8fe66;
 }

--- a/src/components/GraphDisplay.tsx
+++ b/src/components/GraphDisplay.tsx
@@ -14,10 +14,16 @@ const GraphDisplay: React.FC<{
   nodeColour = nodeColour ? nodeColour : '#555577FF';
   lineColour = lineColour ? lineColour : '#7766BBFF';
 
+  function cleanUpSvg(dom) {
+    while (dom.firstChild)
+      dom.removeChild(dom.firstChild);
+    return () => {};
+  }
+
   // Draw graph to screen
-  function renderSvg() {
+  function renderSvg(input) {
     // D3 Setup
-    const data = d3Dag.dagStratify()(inputData);
+    const data = d3Dag.dagStratify()(input);
     const layout = d3Dag.sugiyama()
     .size([300, 1000])
     .coord(leftAlign);
@@ -57,15 +63,21 @@ const GraphDisplay: React.FC<{
       .attr('r', 20)
       .attr('id', d => JSON.stringify(d.id))
       .attr('fill', nodeColour);
+
+    return svgDom;
   }
 
   useEffect(() => {
-    renderSvg();
+    const svgDom = renderSvg(inputData);
+    return cleanUpSvg(svgDom);
   });
 
   return (
-    <div className={graphStyles.graph}>
-      <svg id='graph' width='100%' height='100%' viewBox='-20 -20 1040 340'></svg>
+    <div className={graphStyles.graphContainer}>
+      {(inputData[0].id !== "EMPTY" ? 
+        (<svg id='graph' width='80%' height='100%' viewBox='-20 -20 1040 340'></svg>) :
+        (<div className={graphStyles.emptyGraph}>No Logs Found!</div>)
+      )}
     </div>
   );
 }

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -53,7 +53,7 @@ const DatabaseView: React.FC = withRouter(({ history }) => {
   async function loadData(forceLoad: boolean = false): Promise<void> {
     // Check whether we've already fetched the data. In the future, maybe diff?
     if ((d3data !== null && !forceLoad) || error !== '') {
-      return
+      return;
     }
     setLoading(true);
     try {
@@ -80,7 +80,6 @@ const DatabaseView: React.FC = withRouter(({ history }) => {
       setError(e.toString());
     }
     loadData(true);
-    console.log('added');
   }
 
   const goHome = () => {


### PR DESCRIPTION
When there are no logs in a database, show an empty log message instead of the dummy empty node