### PR TITLE
Inconsistent order

### DIFF
--- a/src/adapters/OrbitDBNodeProvider.ts
+++ b/src/adapters/OrbitDBNodeProvider.ts
@@ -22,7 +22,7 @@ export class OrbitDBNodeProvider implements NodeProvider {
     this.dbInstance = dbInstance;
   }
 
-  async getDatabaseGraph(): Promise<Array<DAGNode>> {
+  async getDatabaseGraph(limit: number): Promise<Array<DAGNode>> {
     // Read head of oplog
     let oplog: any = this.store._oplog;
     let heads: Array<any> = oplog.heads;
@@ -31,7 +31,7 @@ export class OrbitDBNodeProvider implements NodeProvider {
       return [DAGNode.emptyDAG()];
     }
 
-    return DAGNode.createDAG(heads);
+    return DAGNode.createDAG(heads, limit);
   }
 
   getOperationsLog(): OperationsLog {

--- a/src/adapters/OrbitDBNodeProvider.ts
+++ b/src/adapters/OrbitDBNodeProvider.ts
@@ -22,16 +22,16 @@ export class OrbitDBNodeProvider implements NodeProvider {
     this.dbInstance = dbInstance;
   }
 
-  async getDatabaseGraph(): Promise<DAGNode> {
+  async getDatabaseGraph(): Promise<Array<DAGNode>> {
     // Read head of oplog
     let oplog: any = this.store._oplog;
     let heads: Array<any> = oplog.heads;
 
     if (heads.length === 0) {
-      return DAGNode.emptyDAG();
+      return [DAGNode.emptyDAG()];
     }
 
-    return DAGNode.createDAG(heads)[0];
+    return DAGNode.createDAG(heads);
   }
 
   getOperationsLog(): OperationsLog {
@@ -94,7 +94,7 @@ export class OrbitDBNodeProvider implements NodeProvider {
       case OrbitDBDatabaseTypes.EventStore:
         index = new EventIndex();
         break;
-        
+
       case OrbitDBDatabaseTypes.DocumentStore:
         index = new DocumentIndex();
         break;
@@ -102,7 +102,7 @@ export class OrbitDBNodeProvider implements NodeProvider {
       case OrbitDBDatabaseTypes.FeedStore:
         index = new FeedIndex();
         break;
-        
+
       case OrbitDBDatabaseTypes.CounterStore:
         index = new CounterIndex();
         break;
@@ -115,7 +115,7 @@ export class OrbitDBNodeProvider implements NodeProvider {
         console.error("Found unrecognised store type in OrbitDBOperationsLog.");
         return null;
     }
-     
+
     let ipfsLog = operationsLog.getInnerLog();
     index.updateIndex(ipfsLog);
     return index;

--- a/src/components/viewDatabase/GraphDisplay.tsx
+++ b/src/components/viewDatabase/GraphDisplay.tsx
@@ -41,19 +41,19 @@ const GraphDisplay: React.FC<{
   // TODO: Find out types for d.
   function handleMouseEnter(d, domElement: Element) {
     if (mouseEvents !== undefined && mouseEvents.mouseenter !== undefined) {
-      mouseEvents.mouseenter(d.id, domElement);
+      mouseEvents.mouseenter(d.data.payload.actualId, domElement);
     }
   };
 
   function handleMouseLeave(d, domElement: Element) {
     if (mouseEvents !== undefined && mouseEvents.mouseleave !== undefined) {
-      mouseEvents.mouseleave(d.id, domElement);
+      mouseEvents.mouseleave(d.data.payload.actualId, domElement);
     }
   };
 
   function handleOnClick(d, domElement: Element) {
     if (mouseEvents !== undefined && mouseEvents.click !== undefined) {
-      mouseEvents.click(d.id, domElement);
+      mouseEvents.click(d.data.payload.actualId, domElement);
     }
   };
 

--- a/src/components/viewDatabase/GraphDisplay.tsx
+++ b/src/components/viewDatabase/GraphDisplay.tsx
@@ -137,7 +137,7 @@ const GraphDisplay: React.FC<{
 
   return (
     <div className={graphStyles.graphContainer}>
-      {(inputData.id !== "EMPTY" ?
+      {(inputData.payload.actualId !== "EMPTY" ?
         (<svg id='graph' width='100%' height='100%' viewBox={`${viewportOffset} 0 1000 300`} onWheel={scrollSvg}></svg>) :
         (<div className={graphStyles.emptyGraph}>No Logs Found!</div>)
       )}

--- a/src/components/viewDatabase/GraphDisplay.tsx
+++ b/src/components/viewDatabase/GraphDisplay.tsx
@@ -31,7 +31,7 @@ const GraphDisplay: React.FC<{
 
   const viewWidth = 300 * sequentialNodes;
   const viewHeight = heads * 100;
-  const minScroll = -viewWidth / 6;
+  const minScroll = -viewWidth / sequentialNodes;
   const maxScroll = viewWidth / 4;
 
   const colours = ['#555577FF', '#32a891', '#c7942e', '#ff8799', '#ad4949', '#6fd6d4'];
@@ -118,10 +118,6 @@ const GraphDisplay: React.FC<{
   function scrollSvg(e) {
     // const svgWidth = document.getElementsByClassName(graphStyles.graphContainer)[0].clientWidth;
     let offset = viewportOffset + e.deltaY
-    // // return if the svg is smaller than the viewport
-    // if (svgWidth + svgWidth / 2 > viewWidth) {
-    //   return;
-    // }
     if (offset < minScroll) {
       offset = minScroll;
     } else if (offset > maxScroll) {

--- a/src/model/D3Data.ts
+++ b/src/model/D3Data.ts
@@ -94,7 +94,7 @@ const addUserIdentities = async (root: D3Data, nodeProvider: NodeProvider) => {
     return root;
   }
   async function addUserId(node: D3Data) {
-    let promise = nodeProvider.getNodeInfoFromHash(node.id);
+    let promise = nodeProvider.getNodeInfoFromHash(node.payload.actualId);
     for (let child of node.children) {
       addUserId(child);
     }

--- a/src/model/DAGNode.test.ts
+++ b/src/model/DAGNode.test.ts
@@ -1,35 +1,32 @@
-import DAGNode from './DAGNode';
+import DAGNode from "./DAGNode";
 
-const node = new DAGNode("1", [
-  new DAGNode("2", []),
-  new DAGNode("3", [])
-]);
+const node = new DAGNode("1", [new DAGNode("2", []), new DAGNode("3", [])]);
 
-it('outputs correct D3 Data', () => {
-  let d3data = node.toD3Data(Infinity);
+it("outputs correct D3 Data", () => {
+  let d3data = node.toD3Data();
 
   expect(d3data).toEqual(
     expect.objectContaining({
-        id: "1",
-        children: expect.arrayContaining([
-          expect.objectContaining({
-              id: "2",
-              children: expect.arrayContaining([])
-            }
-          ),
-          expect.objectContaining({
-              id: "3",
-              children: expect.arrayContaining([])
-            }
-          )
-        ])
-      }
-    )
-  )
+      id: expect.anything(),
+      children: expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.anything(),
+          payload: expect.objectContaining({
+            actualId: "2"
+          }),
+          children: expect.arrayContaining([])
+        }),
+        expect.objectContaining({
+          id: expect.anything(),
+          payload: expect.objectContaining({
+            actualId: "3"
+          }),
+          children: expect.arrayContaining([])
+        })
+      ]),
+      payload: expect.objectContaining({
+        actualId: "1"
+      })
+    })
+  );
 });
-
-it('correctly limits output size', () => {
-  const limit = 1;
-  let d3data = node.toD3Data(limit);
-  expect(d3data.children.length).toEqual(0);
-})

--- a/src/model/DAGNode.ts
+++ b/src/model/DAGNode.ts
@@ -109,8 +109,6 @@ export default class DAGNode implements D3DataOutput {
 
     let index = Math.min(head.next.length - 1, limit - 2)
 
-    console.log(allNodes)
-
     return allNodes[head.next[index]];
   }
 

--- a/src/pages/OrbitDBDatabaseView.tsx
+++ b/src/pages/OrbitDBDatabaseView.tsx
@@ -91,11 +91,11 @@ const OrbitDBDatabaseView: React.FC = withRouter(({ history }) => {
     if (selectedJoin === null) {
       loadData(true);
     } else {
-      nodeProvider.current.getDatabaseGraph().then(nodes => {
+      nodeProvider.current.getDatabaseGraph(nodeLimit.current).then(nodes => {
         nodes.reduce(async (rootNode, node) => {
           (await rootNode).children.push(await addUserIdentities(
             viewJoinEvent(
-              node.toD3Data(nodeLimit.current),
+              node.toD3Data(),
               storageProvider.current.getJoinEvent(selectedJoin).root
             ),
             nodeProvider.current
@@ -178,10 +178,10 @@ const OrbitDBDatabaseView: React.FC = withRouter(({ history }) => {
     }
     setLoading(true);
     try {
-      let childNodes = await nodeProvider.current.getDatabaseGraph();
+      let childNodes = await nodeProvider.current.getDatabaseGraph(nodeLimit.current);
       let d3data = await childNodes.reduce(async (rootNode, node) => {
         (await rootNode).children.push(await addUserIdentities(
-            node.toD3Data(nodeLimit.current),
+            node.toD3Data(),
           nodeProvider.current
         ));
         return rootNode;

--- a/src/pages/OrbitDBDatabaseView.tsx
+++ b/src/pages/OrbitDBDatabaseView.tsx
@@ -103,11 +103,11 @@ const OrbitDBDatabaseView: React.FC = withRouter(({ history }) => {
           return rootNode;
         }, Promise.resolve({id: "ROOT", children: [], payload: {}}))
           .then((d3data) => {
+            // Remove ROOT node if there is only a single root
+            d3data = d3data.children.length === 1 ? d3data.children[0] : d3data;
             setD3data(d3data);
         });
-
       });
-
     }
     // For some reason, ESLint thinks loadData should be a dependency
     // eslint-disable-next-line
@@ -186,6 +186,8 @@ const OrbitDBDatabaseView: React.FC = withRouter(({ history }) => {
         ));
         return rootNode;
       }, Promise.resolve({id: "ROOT", children: [], payload: {}}));
+      // Remove ROOT node if there is only a single root
+      d3data = d3data.children.length === 1 ? d3data.children[0] : d3data;
       setD3data(d3data);
     } catch (e) {
       setError(e.toString());

--- a/src/providers/NodeProvider.ts
+++ b/src/providers/NodeProvider.ts
@@ -2,10 +2,10 @@ import DAGNode from "../model/DAGNode";
 import OperationsLog from "./OperationsLog";
 
 export interface NodeProvider {
-  getDatabaseGraph(): Promise<DAGNode>;
+  getDatabaseGraph(): Promise<Array<DAGNode>>;
 
   listenForDatabaseGraph(cb: () => void): void;
-  
+
   /**
    * @param {() => void} cb The callback to run after intercepting a local write event.
    */

--- a/src/providers/NodeProvider.ts
+++ b/src/providers/NodeProvider.ts
@@ -2,7 +2,7 @@ import DAGNode from "../model/DAGNode";
 import OperationsLog from "./OperationsLog";
 
 export interface NodeProvider {
-  getDatabaseGraph(): Promise<Array<DAGNode>>;
+  getDatabaseGraph(limit: number): Promise<Array<DAGNode>>;
 
   listenForDatabaseGraph(cb: () => void): void;
 

--- a/src/utils/NodePlotter.js
+++ b/src/utils/NodePlotter.js
@@ -21,7 +21,7 @@ export default function() {
           console.log(layer[i].data.children[0])
           console.log(prevlayer);
           const prevIndex = prevlayer.findIndex(node => node.children.reduce((found, cNode) => {
-            return found || layer[i].id == cNode.id;
+            return found || layer[i].id === cNode.id;
           }, false));
           layer[i].x = widths[max][prevIndex];
         } else {

--- a/src/utils/NodePlotter.js
+++ b/src/utils/NodePlotter.js
@@ -16,7 +16,7 @@ export default function() {
       max = max < layer.length ? layer.length : max;
       for (let i = 0; i < layer.length; i++) {
         if (layer.length < max) {
-          const prevIndex = prevlayer.findIndex(node => node.id === layer[i].data.parentIds[0]);
+          const prevIndex = prevlayer.findIndex(node => node.id === layer[i].data.children[0]);
           layer[i].x = widths[max][prevIndex];
         } else {
           layer[i].x = widths[max][i];

--- a/src/utils/NodePlotter.js
+++ b/src/utils/NodePlotter.js
@@ -16,7 +16,13 @@ export default function() {
       max = max < layer.length ? layer.length : max;
       for (let i = 0; i < layer.length; i++) {
         if (layer.length < max) {
-          const prevIndex = prevlayer.findIndex(node => node.id === layer[i].data.children[0]);
+          // This layer is not as wide as the maximum so far
+          // So use x-coordinate of the previous, to keep the layer straight
+          console.log(layer[i].data.children[0])
+          console.log(prevlayer);
+          const prevIndex = prevlayer.findIndex(node => node.children.reduce((found, cNode) => {
+            return found || layer[i].id == cNode.id;
+          }, false));
           layer[i].x = widths[max][prevIndex];
         } else {
           layer[i].x = widths[max][i];

--- a/src/utils/NodePlotter.js
+++ b/src/utils/NodePlotter.js
@@ -18,8 +18,6 @@ export default function() {
         if (layer.length < max) {
           // This layer is not as wide as the maximum so far
           // So use x-coordinate of the previous, to keep the layer straight
-          console.log(layer[i].data.children[0])
-          console.log(prevlayer);
           const prevIndex = prevlayer.findIndex(node => node.children.reduce((found, cNode) => {
             return found || layer[i].id === cNode.id;
           }, false));


### PR DESCRIPTION
Closes #118 #55 

Fixes an issue where a database can have the same nodes in different heads, in a different order.

In this case, we just display both heads as straight dags separately.